### PR TITLE
Add support for VB.NET, C#, JS, CSS and HTML

### DIFF
--- a/FreeMyCode_cmd/Config.json
+++ b/FreeMyCode_cmd/Config.json
@@ -29,6 +29,32 @@
       "Bloc comment opening": "",
       "Bloc comment closing": "",
       "Single line comment": "#"
+    },
+    {
+      "extension": ".cs",
+      "Bloc comment opening": "/*",
+      "Bloc comment closing": "*/",
+      "Single line comment": "//"
+    },
+    {
+      "extension": ".js",
+      "Bloc comment opening": "/*",
+      "Bloc comment closing": "*/",
+      "Single line comment": "//"
+    },
+    {
+      "extension": ".html",
+      "Bloc comment opening": "<!--",
+      "Bloc comment closing": "-->",
+    },
+    {
+      "extension": ".css",
+      "Bloc comment opening": "/*",
+      "Bloc comment closing": "*/"
+    },
+    {
+      "extension": ".vb",
+      "Single line comment": "\'"
     }
   ]
 }


### PR DESCRIPTION
- VB.NET does not support bloc comment
- CSS and HTML  does not support single line comment the way it's implemented here

:warning: The following chars should be escaped in JSON (for VB.NET for example) :

- `‘` single quote
- `"` quote
- `\` backslash
- all control characters like `\n` `\t`